### PR TITLE
Fix path to logo for gallery display

### DIFF
--- a/_gallery_info.yml
+++ b/_gallery_info.yml
@@ -1,4 +1,4 @@
-thumbnail: https://projectpythia.org/esgf-cookbook/_images/esgf2-us.png
+thumbnail: notebooks/images/logos/esgf2-us.png
 tags:
   domains:
     - Climate


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
As mentioned at https://github.com/ProjectPythia/cookbook-gallery/pull/219, the logo is not displaying on the gallery card. This PR should fix that.

Our gallery script doesn't currently support giving paths to logos as absolute URLs (though maybe it should).