### PR TITLE
Add cook-off event tag for gallery filtering

### DIFF
--- a/_gallery_info.yml
+++ b/_gallery_info.yml
@@ -8,3 +8,5 @@ tags:
   packages:
     - Xarray
     - Intake-esgf
+  events:
+    - Cook-off 2024


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
No effect on the Cookbook itself, just the filterable tags displayed on the Pythia gallery.